### PR TITLE
Added pessimist locking to update and test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ project(":core") {
         "implementation"("com.fasterxml.jackson.module:jackson-module-kotlin")
         "implementation"("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         "implementation"("org.jetbrains.kotlin:kotlin-reflect")
+        "implementation"("org.springframework.boot:spring-boot-starter-data-jpa")
     }
     tasks.getByName<BootJar>("bootJar") {
         enabled = false
@@ -107,5 +108,6 @@ project(":app") {
         "testImplementation"("org.mockito.kotlin:mockito-kotlin:3.2.0")
         "testImplementation"("com.fasterxml.jackson.module:jackson-module-kotlin")
         "testImplementation"("org.apache.httpcomponents:httpclient")
+        "implementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0-RC")
     }
 }

--- a/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/RedirectUseCase.kt
+++ b/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/RedirectUseCase.kt
@@ -3,7 +3,10 @@ package es.unizar.urlshortener.core.usecases
 import es.unizar.urlshortener.core.Redirection
 import es.unizar.urlshortener.core.RedirectionNotFound
 import es.unizar.urlshortener.core.ShortUrlRepositoryService
-import java.time.OffsetDateTime
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.transaction.annotation.Transactional
+import javax.persistence.LockModeType
 
 /**
  * Given a key returns a [Redirection] that contains a [URI target][Redirection.target]
@@ -18,9 +21,11 @@ interface RedirectUseCase {
 /**
  * Implementation of [RedirectUseCase].
  */
-class RedirectUseCaseImpl(
+open class RedirectUseCaseImpl(
     private val shortUrlRepository: ShortUrlRepositoryService
 ) : RedirectUseCase {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Transactional
     override fun redirectTo(key: String): Redirection =
         shortUrlRepository.findByKey(key)?.let {
             shortUrlRepository.updateLeftUses(it)

--- a/repositories/src/main/kotlin/es/unizar/urlshortener/infrastructure/repositories/Repositories.kt
+++ b/repositories/src/main/kotlin/es/unizar/urlshortener/infrastructure/repositories/Repositories.kt
@@ -2,12 +2,14 @@ package es.unizar.urlshortener.infrastructure.repositories
 
 import es.unizar.urlshortener.core.ShortUrl
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
 import javax.persistence.PersistenceContext
 import java.util.Date
+import javax.persistence.LockModeType
 
 /**
  * Specification of the repository of [ShortUrlEntity].
@@ -15,6 +17,7 @@ import java.util.Date
  * **Note**: Spring Boot is able to discover this [JpaRepository] without further configuration.
  */
 interface ShortUrlEntityRepository : JpaRepository<ShortUrlEntity, String> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByHash(hash: String): ShortUrlEntity?
 
     @Transactional


### PR DESCRIPTION
Note: Testing this implies generating 500 concurrent request, it takes time (~3m30s local).